### PR TITLE
設定ファイル作成直後、MOGRTのインポートに失敗する挙動を修正

### DIFF
--- a/js/setting.js
+++ b/js/setting.js
@@ -108,6 +108,10 @@ function NewSettingFile() {
         const err = SaveSettings();
         if(err == window.cep.fs.NO_ERROR){
             csInterface.evalScript(makeEvalScript('ImportSettingsFile', ExtensionSettingsFilePath));
+            ExtensionSettings[E_SETTING_ui_params] = {};
+            ExtensionSettings[E_SETTING_version] = 1;
+            ExtensionSettings[E_SETTING_actors] = {};
+            ExtensionSettings[E_SETTING_mogrts] = {};
             $('#setting_file_not_exist_icon').css('visibility','hidden');
             $('#setting_save_modal_close').click();
         } else {


### PR DESCRIPTION
## 修正の背景
画面から設定ファイル(2dActorTools_settings.txt)作成後そのままMOGRTファイルをインポートした場合、以下のエラーにより失敗します。
![era-](https://user-images.githubusercontent.com/70102274/199733078-0b0062ab-c9c4-4b1a-91cf-bda771b6fd91.JPG)
エラーとなる原因はスタックトレースの通り、SetMogrtPath関数がExtensionSettingsオブジェクトを参照する際、E_SETTING_mogrts(mogrts)プロパティが存在しないためです。
現状、E_SETTING_mogrtsを含むExtensionSettingsオブジェクトのプロパティはパネル起動時(loadSetup関数)と設定ファイルのインポート時(ImportSettingFile関数)にのみ設定されます。
従って、設定ファイルを新規に作成した場合(おそらく多くの場合新規環境構築時)は、パネルを開き直さなければ設定されず、結果としてmorgtファイルのインポートが出来ません。

## 修正概要
NewSettingFile関数を修正し、設定ファイル(2dActorTools_settings.txt)を新規作成する際にExtensionSettingsのプロパティを初期化します。
上記エラーを回避するのみであればE_SETTING_mogrtsのみを設定すれば十分ですが、今後の拡張時に同様のエラーを予防する意味でE_SETTING_ui_params、E_SETTING_version、E_SETTING_actorsも初期化する形としてみました。