### PR TITLE
設定ファイル新規作成後、MOGRTのインポート等が失敗する挙動を修正

### DIFF
--- a/js/setting.js
+++ b/js/setting.js
@@ -107,11 +107,9 @@ function NewSettingFile() {
         ExtensionSettingsFilePath = savedir + '/2dActorTools_settings.txt';
         const err = SaveSettings();
         if(err == window.cep.fs.NO_ERROR){
-            csInterface.evalScript(makeEvalScript('ImportSettingsFile', ExtensionSettingsFilePath));
-            ExtensionSettings[E_SETTING_ui_params] = {};
-            ExtensionSettings[E_SETTING_version] = 1;
-            ExtensionSettings[E_SETTING_actors] = {};
-            ExtensionSettings[E_SETTING_mogrts] = {};
+            csInterface.evalScript(makeEvalScript('ImportSettingsFile', ExtensionSettingsFilePath), function(){
+                _LoadSettings();
+            });
             $('#setting_file_not_exist_icon').css('visibility','hidden');
             $('#setting_save_modal_close').click();
         } else {

--- a/js/setting.js
+++ b/js/setting.js
@@ -108,6 +108,10 @@ function NewSettingFile() {
         const err = SaveSettings();
         if(err == window.cep.fs.NO_ERROR){
             csInterface.evalScript(makeEvalScript('ImportSettingsFile', ExtensionSettingsFilePath));
+            ExtensionSettings[E_SETTING_ui_params] = {};
+            ExtensionSettings[E_SETTING_version] = 1;
+            ExtensionSettings[E_SETTING_actors] = {};
+            ExtensionSettings[E_SETTING_mogrts] = {};
             $('#setting_file_not_exist_icon').css('visibility','hidden');
             $('#setting_save_modal_close').click();
         } else {


### PR DESCRIPTION
## 検証環境
Releases v1.3.3
Microsoft Windows [Version 10.0.19044.2130]
Adobe Premier Pro 23.0.0

## 修正の背景
パネルから設定ファイル(2dActorTools_settings.txt)作成後、そのままMOGRTファイルをインポート等の操作を行った場合、以下のエラーにより失敗します。

MOGRTファイルのインポートを例にとると、
![エラー画像](https://user-images.githubusercontent.com/70102274/199758428-3470b4b7-5836-4fd4-af19-32b6b867b398.png)
![修正前](https://user-images.githubusercontent.com/70102274/199758558-15ccbe54-457c-4c14-b05f-5202bc223759.png)
エラーとなる原因は上記の通り、SetMogrtPath関数がExtensionSettingsオブジェクトを参照する際、E_SETTING_mogrts(mogrts)プロパティが存在しないためです。

現状、E_SETTING_mogrtsを含むExtensionSettingsオブジェクトのプロパティは設定ファイルが既に存在する状態でパネルを起動した時(loadSetup関数)と、設定ファイルをインポートした時(ImportSettingFile関数)にのみ設定されます。
従って、設定ファイルを新規に作成した場合(おそらく多くの場合新規環境構築時)は、パネルを開き直さなければ設定されず、そのままではMOGRTファイルのインポートが出来ません。

同様の理由で、文字コードやフレームレートの設定、自動インポートのファイルパスの指定(SettingUpdate関数)など、ExtensionSettingsが持つプロパティに依存する様々な処理が失敗します。
## 修正概要
NewSettingFile関数を修正し、設定ファイル(2dActorTools_settings.txt)を新規作成する際にExtensionSettingsのプロパティを初期化します。

これによって設定ファイル新作成直後でもパネルの開き直しを必要とせずMOGRTファイルのインポート等ができることを確認しています。
![修正後](https://user-images.githubusercontent.com/70102274/199758840-b74e5175-67b2-4a1d-b7d0-5e4abb8ab085.png)